### PR TITLE
Add mismatched? method to make work with newer version of Rails

### DIFF
--- a/activesupport-db-cache.gemspec
+++ b/activesupport-db-cache.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "activesupport-db-cache"
   gem.require_paths = ["lib"]
-  gem.version       = '0.0.3'
+  gem.version       = '0.0.4'
 
   gem.add_dependency "activesupport", ">=4.0.0"
   gem.add_dependency "activerecord", ">=4.0.0"

--- a/lib/active_support/cache/active_record_store.rb
+++ b/lib/active_support/cache/active_record_store.rb
@@ -46,6 +46,10 @@ module ActiveSupport
           read_attribute(:expires_at).try(:past?) || false
         end
 
+        def mismatched?(version)
+          meta_info.fetch(:version, nil) && version && meta_info[:version] != version
+        end
+
         # From ActiveSupport::Cache::Store::Entry
         # Seconds since the epoch when the entry will expire.
         def expires_at


### PR DESCRIPTION
Rails 5.2 doesn't have `mismatched?` as a method on the Entity class. This adds it back in. 